### PR TITLE
Fix partial_corr intercept (shift-invariance)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 dist/*
 timeawarepc.egg-info/*
+__pycache__/
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Fixed
+- `partial_corr` (in both `timeawarepc/pcalg.py` and `timeawarepc/pcalg_helpers.py`) now fits an intercept in the conditioning regression, making the partial correlation shift-invariant (invariant to adding a constant to the data). Previously, the regression was forced through the origin, which biased the residuals when the data was not mean-centered.
+- Added regression test (`test/test_partial_corr_shift_invariance.py`) verifying that `partial_corr` produces the same result before and after a constant shift of the data.

--- a/test/test_partial_corr_shift_invariance.py
+++ b/test/test_partial_corr_shift_invariance.py
@@ -1,0 +1,61 @@
+"""Regression test: partial_corr should be shift-invariant.
+
+Adding a constant to the input data should not change the partial correlation,
+because the underlying linear regression now includes an intercept term.
+"""
+import os
+import sys
+
+# Insert project root before any installed timeawarepc so the tests run
+# against the in-repo source, not any pre-installed package version.
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+import numpy as np
+
+from timeawarepc.pcalg import partial_corr as partial_corr_pcalg
+from timeawarepc.pcalg_helpers import partial_corr as partial_corr_helpers
+
+
+def _make_test_data(seed: int = 0, n: int = 200):
+    rng = np.random.default_rng(seed)
+    # 3 variables; var 2 is a linear combination of vars 0 and 1 plus noise
+    data = rng.standard_normal((n, 3))
+    data[:, 2] = data[:, 0] + 0.5 * data[:, 1] + 0.1 * rng.standard_normal(n)
+    return data
+
+
+def test_partial_corr_pcalg_shift_invariant():
+    data = _make_test_data()
+    r_orig = partial_corr_pcalg(0, 2, {1}, data)
+    r_shift = partial_corr_pcalg(0, 2, {1}, data + 10.0)
+    assert np.isclose(r_orig, r_shift, atol=1e-8), (
+        f"partial_corr (pcalg) not shift-invariant: {r_orig} vs {r_shift}"
+    )
+
+
+def test_partial_corr_helpers_shift_invariant():
+    data = _make_test_data()
+    r_orig = partial_corr_helpers(data, 0, 2, {1})
+    r_shift = partial_corr_helpers(data + 10.0, 0, 2, {1})
+    assert np.isclose(r_orig, r_shift, atol=1e-8), (
+        f"partial_corr (helpers) not shift-invariant: {r_orig} vs {r_shift}"
+    )
+
+
+def test_partial_corr_pcalg_matches_helpers():
+    """Both partial_corr implementations should agree."""
+    data = _make_test_data()
+    r1 = partial_corr_pcalg(0, 2, {1}, data)
+    r2 = partial_corr_helpers(data, 0, 2, {1})
+    assert np.isclose(r1, r2, atol=1e-8), (
+        f"partial_corr disagreement between pcalg and helpers: {r1} vs {r2}"
+    )
+
+
+if __name__ == "__main__":
+    test_partial_corr_pcalg_shift_invariant()
+    test_partial_corr_helpers_shift_invariant()
+    test_partial_corr_pcalg_matches_helpers()
+    print("All tests passed.")

--- a/timeawarepc/pcalg.py
+++ b/timeawarepc/pcalg.py
@@ -419,16 +419,20 @@ def partial_corr(A,B,S,data):
     for i in range(p):
         if i in S:
             idx[i]=True
-    C=data
-    beta_A = linalg.lstsq(C[:,idx], C[:,A])[0]
-    beta_B = linalg.lstsq(C[:,idx], C[:,B])[0]
+    C = data
 
-    res_A = C[:,A] - C[:, idx].dot(beta_A)
-    res_B = C[:,B] - C[:, idx].dot(beta_B)
-    
-    p_corr = stats.pearsonr(res_A, res_B)[0]  
-    
-    return p_corr
+    # conditioning matrix: (n_samples, n_conditioning_vars)
+    # prepend a column of ones so lstsq fits an intercept -> shift-invariant
+    Z = C[:, idx]
+    Z = np.column_stack([np.ones(Z.shape[0]), Z])
+
+    beta_A = linalg.lstsq(Z, C[:, A])[0]
+    beta_B = linalg.lstsq(Z, C[:, B])[0]
+
+    res_A = C[:, A] - Z.dot(beta_A)
+    res_B = C[:, B] - Z.dot(beta_B)
+
+    return stats.pearsonr(res_A, res_B)[0]
 if __name__ == '__main__':
     import networkx as nx
     import numpy as np

--- a/timeawarepc/pcalg_helpers.py
+++ b/timeawarepc/pcalg_helpers.py
@@ -43,13 +43,17 @@ def partial_corr(data,A,B,S):
     for i in range(p):
         if i in S:
             idx[i]=True
-    C=data
-    beta_A = linalg.lstsq(C[:,idx], C[:,A])[0]
-    beta_B = linalg.lstsq(C[:,idx], C[:,B])[0]
+    C = data
 
-    res_A = C[:,A] - C[:, idx].dot(beta_A)
-    res_B = C[:,B] - C[:, idx].dot(beta_B)
-    
-    p_corr = stats.pearsonr(res_A, res_B)[0]  
-    
-    return p_corr
+    # conditioning matrix: (n_samples, n_conditioning_vars)
+    # prepend a column of ones so lstsq fits an intercept -> shift-invariant
+    Z = C[:, idx]
+    Z = np.column_stack([np.ones(Z.shape[0]), Z])
+
+    beta_A = linalg.lstsq(Z, C[:, A])[0]
+    beta_B = linalg.lstsq(Z, C[:, B])[0]
+
+    res_A = C[:, A] - Z.dot(beta_A)
+    res_B = C[:, B] - Z.dot(beta_B)
+
+    return stats.pearsonr(res_A, res_B)[0]


### PR DESCRIPTION
## Summary
Fixes a bug where `partial_corr` in `timeawarepc/pcalg.py` and `timeawarepc/pcalg_helpers.py` was not shift-invariant. The conditioning regression was forced through the origin (no intercept fit), so adding a constant to the input data would change the partial correlation result.

## Fix
Prepend a column of ones to the conditioning matrix `Z` in both `partial_corr` implementations before calling `linalg.lstsq`, so the regression now includes an intercept term. The residuals (and therefore the resulting partial correlation) are now invariant to translation of the input data.

This is the same fix that was applied to the CITS package in v1.4 (see commit `6194e20` in [abbasilab/cits](https://github.com/abbasilab/cits)).

## Changes
- `timeawarepc/pcalg.py:413` — `partial_corr` now fits an intercept
- `timeawarepc/pcalg_helpers.py:28` — `partial_corr` now fits an intercept
- `test/test_partial_corr_shift_invariance.py` — new regression test verifying shift-invariance and parity between the two implementations
- `CHANGELOG.md` — new file documenting the fix
- `.gitignore` — add `__pycache__/` and `*.pyc`

## Test plan
- [x] Run `python test/test_partial_corr_shift_invariance.py` — all three tests pass:
  - `test_partial_corr_pcalg_shift_invariant`
  - `test_partial_corr_helpers_shift_invariant`
  - `test_partial_corr_pcalg_matches_helpers`
- [ ] CI (if configured) passes on this branch
- [ ] Manual sanity check that downstream `cfc_tpc` / `cfc_pc` results on existing datasets are consistent (small numerical changes expected for data with non-zero mean)